### PR TITLE
Traer a mover corrección de main

### DIFF
--- a/Ajedrez.vcxproj
+++ b/Ajedrez.vcxproj
@@ -150,6 +150,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="src\Alfil.cpp" />
+    <ClCompile Include="src\AyudaTexto.cpp" />
     <ClCompile Include="src\Coordinador.cpp" />
     <ClCompile Include="src\Dama.cpp" />
     <ClCompile Include="src\main.cpp" />
@@ -163,6 +164,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\Alfil.h" />
+    <ClInclude Include="src\AyudaTexto.h" />
     <ClInclude Include="src\Caballo.h" />
     <ClInclude Include="src\Coordinador.h" />
     <ClInclude Include="src\Dama.h" />

--- a/Ajedrez.vcxproj.filters
+++ b/Ajedrez.vcxproj.filters
@@ -48,6 +48,9 @@
     <ClCompile Include="src\Coordinador.cpp">
       <Filter>Archivos de origen</Filter>
     </ClCompile>
+    <ClCompile Include="src\AyudaTexto.cpp">
+      <Filter>Archivos de origen</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\Piezas.h">
@@ -78,6 +81,9 @@
       <Filter>Archivos de encabezado</Filter>
     </ClInclude>
     <ClInclude Include="src\Coordinador.h">
+      <Filter>Archivos de encabezado</Filter>
+    </ClInclude>
+    <ClInclude Include="src\AyudaTexto.h">
       <Filter>Archivos de encabezado</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Traer a la rama la corrección de un error en uno de los archivos del proyecto, para que se incluyan correctamente los dos ficheros de la librería AyudaTexto.